### PR TITLE
Remove unused virtual functions / use pure virtual functions

### DIFF
--- a/qhimdtransfer/qmddevice.h
+++ b/qhimdtransfer/qmddevice.h
@@ -48,12 +48,11 @@ public:
     virtual void * deviceHandle();
     virtual void registerMdChange(void * regMdChange);
     virtual void * MdChange();
-    virtual QMDTrack track(unsigned int trkindex) {return QMDTrack();}
     virtual int trackCount() {return trk_count;}
     virtual QStringList downloadableFileExtensions() const;
     virtual void checkfile(QString UploadDirectory, QString &filename, QString extension);
-    virtual void batchUpload(QMDTrackIndexList tlist, QString path) {}
-    virtual void upload(unsigned int trackidx, QString path) {}
+    virtual void batchUpload(QMDTrackIndexList tlist, QString path) = 0;
+    virtual void upload(unsigned int trackidx, QString path) = 0;
 
 signals:
     void opened();

--- a/qhimdtransfer/qmdmodel.h
+++ b/qhimdtransfer/qmdmodel.h
@@ -11,16 +11,12 @@
 class QMDTracksModel : public QAbstractListModel {
     Q_OBJECT
 
-    QMDDevice * dev;
 public:
-    QMDTracksModel() : dev(NULL) {}
-    /* QAbstractListModel stuff */
-    virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const {return QVariant();}
-    virtual QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const {return QVariant();}
-    virtual int rowCount(const QModelIndex & parent = QModelIndex() ) const {return 0;}
-    virtual int columnCount(const QModelIndex & parent = QModelIndex() ) const {return 0;}
+    QMDTracksModel() {}
+    /* Make this method from QAbstractListModel public */
+    virtual int columnCount(const QModelIndex & parent = QModelIndex() ) const = 0;
     /* dummy data for unknown devices */
-    virtual QString open(QMDDevice *device = NULL) {return tr("no known device type specified");}
+    virtual QString open(QMDDevice *device = NULL) = 0;
     virtual bool is_open() {return false;}
     virtual void close() {}
 };


### PR DESCRIPTION
Removed some dead code that was never reached. As there are only two known subclasses (NetMD- and HiMD-specific) for each of these classes, there's no need for the base class to provide a dummy implementation.
