### PR TITLE
libhimd: Add missing #include directives, fix unused parameters, cast id3tag return types

### DIFF
--- a/libhimd/himd.c
+++ b/libhimd/himd.c
@@ -31,7 +31,9 @@
 
 #define G_LOG_DOMAIN "HiMD"
 #include <glib.h>
+#include <glib/gstdio.h>
 #include "himd.h"
+#include "himd_private.h"
 
 #define _(x) (x)
 

--- a/libhimd/himd.c
+++ b/libhimd/himd.c
@@ -165,7 +165,7 @@ int himd_write_tifdata(struct himd * himd, struct himderrinfo * status)
     gchar *filepath;
     GDir * dir;
     GError * error = NULL;
-    status = status;
+    (void)status;
 
     filepath = g_build_filename(himd->rootpath,himd->need_lowercase ? "hmdhifi" : "HMDHIFI", NULL);
     dir      = g_dir_open(filepath,0,&error);

--- a/libhimd/mdstream.c
+++ b/libhimd/mdstream.c
@@ -250,8 +250,8 @@ int himd_writestream_write(struct himd_writestream * stream, struct blockinfo * 
     unsigned char data[HIMD_BLOCKINFO_SIZE];
     g_return_val_if_fail(stream != NULL, -1);
     g_return_val_if_fail(audioblock != NULL, -1);
-    status = status;
-    stream = stream;
+
+    (void)status;
 
     // serialize the block descriptor
     setblock(audioblock, data);

--- a/libhimd/mp3tools.c
+++ b/libhimd/mp3tools.c
@@ -25,6 +25,7 @@
 
 #include <id3tag.h>
 #include "himd.h"
+#include "himd_private.h"
 
 /*
  * gets artist, title and album info from an ID3 tag.

--- a/libhimd/mp3tools.c
+++ b/libhimd/mp3tools.c
@@ -27,6 +27,11 @@
 #include "himd.h"
 #include "himd_private.h"
 
+static inline char *dup_id3_first_string(union id3_field const *field)
+{
+    return (char *)id3_ucs4_utf8duplicate(id3_field_getstrings(field, 0));
+}
+
 /*
  * gets artist, title and album info from an ID3 tag.
  * The output strings are to be free()d.
@@ -52,21 +57,21 @@ int himd_get_songinfo(const char *filepath, char ** artist, char ** title, char 
     frame = id3_tag_findframe (tag, ID3_FRAME_ARTIST, 0);
     if(frame && (field = &frame->fields[1]) &&
                  id3_field_getnstrings(field) > 0)
-        *artist = id3_ucs4_utf8duplicate(id3_field_getstrings(field,0));
+        *artist = dup_id3_first_string(field);
     else
         *artist = NULL;
 
     frame = id3_tag_findframe (tag, ID3_FRAME_TITLE, 0);
     if(frame && (field = &frame->fields[1]) &&
                  id3_field_getnstrings(field) > 0)
-        *title = id3_ucs4_utf8duplicate(id3_field_getstrings(field,0));
+        *title = dup_id3_first_string(field);
     else
         *title = NULL;
 
     frame = id3_tag_findframe (tag, ID3_FRAME_ALBUM, 0);
     if(frame && (field = &frame->fields[1]) &&
                  id3_field_getnstrings(field) > 0)
-        *album = id3_ucs4_utf8duplicate(id3_field_getstrings(field,0));
+        *album = dup_id3_first_string(field);
     else
         *album = NULL;
 

--- a/libhimd/trackindex.c
+++ b/libhimd/trackindex.c
@@ -245,7 +245,7 @@ int himd_add_track_info(struct himd * himd, struct trackinfo * t, struct himderr
     unsigned char * trackbuffer;
     unsigned char * play_order_table = himd->tifdata+0x100;
 
-    status = status;
+    (void)status;
 
     g_return_val_if_fail(himd != NULL, -1);
     g_return_val_if_fail(t != NULL, -1);
@@ -352,7 +352,8 @@ int himd_add_fragment_info(struct himd * himd, struct fraginfo * f, struct himde
     int idx_freefrag;
     unsigned char * linkbuffer;
     unsigned char * fragbuffer;
-    status = status;
+
+    (void)status;
 
     g_return_val_if_fail(himd != NULL, -1);
     g_return_val_if_fail(f != NULL, -1);


### PR DESCRIPTION
This avoids compiler warnings with recent versions of clang.
