### PR TITLE
netmdcli: Format string fixes, fix netmd_get_devname() API in libnetmd

### DIFF
--- a/libnetmd/netmd_dev.c
+++ b/libnetmd/netmd_dev.c
@@ -130,11 +130,11 @@ netmd_error netmd_open(netmd_device *dev, netmd_dev_handle **dev_handle)
     }
 }
 
-netmd_error netmd_get_devname(netmd_dev_handle* devh, unsigned char* buf, size_t buffsize)
+netmd_error netmd_get_devname(netmd_dev_handle* devh, char *buf, size_t buffsize)
 {
     int result;
 
-    result = libusb_get_string_descriptor_ascii((libusb_device_handle *)devh, 2, buf, buffsize);
+    result = libusb_get_string_descriptor_ascii((libusb_device_handle *)devh, 2, (unsigned char *)buf, buffsize);
     if (result < 0) {
         netmd_log(NETMD_LOG_ERROR, "libusb_get_string_descriptor_asci failed, %s (%d)\n", strerror(errno), errno);
         buf[0] = 0;

--- a/libnetmd/netmd_dev.h
+++ b/libnetmd/netmd_dev.h
@@ -43,7 +43,7 @@ netmd_error netmd_open(netmd_device *dev, netmd_dev_handle **dev_handle);
   @param buf Buffer to hold the name.
   @param buffsize Available size in buf.
 */
-netmd_error netmd_get_devname(netmd_dev_handle* devh, unsigned char* buf, size_t buffsize);
+netmd_error netmd_get_devname(netmd_dev_handle* devh, char *buf, size_t buffsize);
 
 /**
   Closes the usb descriptors.

--- a/netmdcli/netmdcli.c
+++ b/netmdcli/netmdcli.c
@@ -125,7 +125,7 @@ static void send_raw_message(netmd_dev_handle* devh, char *pszRaw)
         szBuf[1] = *pszRaw++;
         szBuf[2] = '\0';
         if (sscanf(szBuf, "%02X", &data) != 1) {
-            printf("Error: invalid character at byte %d ('%s')\n", cmdlen, szBuf);
+            printf("Error: invalid character at byte %zu ('%s')\n", cmdlen, szBuf);
             return;
         }
         cmd[cmdlen++] = data & 0xff;


### PR DESCRIPTION
Two small compiler warning fixes for netmdcli.
