### PR TITLE
md.pro: Fix subproject dependencies / parallel builds

### DIFF
--- a/README
+++ b/README
@@ -10,10 +10,10 @@ sox 14.2 (for the GUI)
 BUILDING
 
 This project uses the qmake build system to cooperate with the Qt Creator
-IDE. To compile in Qt Creator, just open himd.pro. To compile at the
+IDE. To compile in Qt Creator, just open md.pro. To compile at the
 command line, run
 
-  qmake -r
+  qmake
   make
 
 Depending on the default configuration of your system, you will find
@@ -24,9 +24,9 @@ To disable the optional features, the following keywords are recognized
 in the CONFIG variable:
   without_mad -> disables MP3 support (you wont need mad)
   without_mcrypt -> disables PCM support (you wont need libmcrypt)
-  wihtout_gui -> disable qhimdtransfer (you wont need Qt and sox)
+  without_gui -> disable qhimdtransfer (you wont need Qt and sox)
 
 So, the minimal configuration is built by using
 
-  qmake -r CONFIG+=without_mad CONFIG+=without_mcrypt CONFIG+=without_gui
+  qmake CONFIG+=without_mad CONFIG+=without_mcrypt CONFIG+=without_gui
 

--- a/md.pro
+++ b/md.pro
@@ -1,6 +1,11 @@
-TEMPLATE =subdirs
-CONFIG   +=order
-SUBDIRS  = libnetmd libhimd netmdcli himdcli
+TEMPLATE = subdirs
+
+SUBDIRS = libnetmd libhimd netmdcli himdcli
+
+netmdcli.depends = libnetmd
+himdcli.depends = libhimd
+
 !without_gui: {
   SUBDIRS += qhimdtransfer
+  qhimdtransfer.depends = libhimd libnetmd
 }


### PR DESCRIPTION
The `CONFIG += order` probably doesn't do anything. There's a `CONFIG += ordered`, but it's use is [discouraged](https://blog.rburchell.com/2013/10/every-time-you-configordered-kitten-dies.html). This change makes the subdirs dependencies explicit and allows proper subproject building (e.g. `make sub-netmdcli`) as well as parallel builds (e.g. `make -j8`).
