### PR TITLE
qhimdtransfer: Only prepend artist if not empty

### DIFF
--- a/qhimdtransfer/qmddevice.cpp
+++ b/qhimdtransfer/qmddevice.cpp
@@ -599,11 +599,15 @@ void QHiMDDevice::upload(unsigned int trackidx, QString path)
     QString filename, errmsg;
     QHiMDTrack track = himdTrack(trackidx);
     QString title = track.title();
+    QString artist = track.artist();
 
-    if(title.isNull())
+    if(title.isEmpty()) {
         filename = tr("Track %1").arg(track.tracknum()+1);
-    else
-        filename = track.artist() + " - " + title;
+    } else if (artist.isEmpty()) {
+        filename = title;
+    } else {
+        filename = artist + " - " + title;
+    }
 
     uploadDialog.starttrack(track, filename);
     if (!track.copyprotected())


### PR DESCRIPTION
When uploading files, do not prepend the artist name if it is empty. This avoids filenames like:

`" - Title.oma"`

in favor of

`"Title.oma"`

when there is no artist name set on the track.

In the future, we might even want to make this configurable, so the user can choose to also include the track number, album name, etc...
