### PR TITLE
OS X: Do not build an .app bundle for CLI tools

### DIFF
--- a/himdcli/himdcli.pro
+++ b/himdcli/himdcli.pro
@@ -16,3 +16,7 @@ unix:!macx {
   LIBS += -lmad
   DEFINES += CONFIG_WITH_MAD
 }
+
+macx {
+  CONFIG -= app_bundle
+}

--- a/netmdcli/netmdcli.pro
+++ b/netmdcli/netmdcli.pro
@@ -13,3 +13,7 @@ unix:!macx {
 }
 
 mac:INCLUDEPATH += /opt/local/include
+
+macx {
+  CONFIG -= app_bundle
+}


### PR DESCRIPTION
Re-issue of https://github.com/glaubitz/linux-minidisc/pull/2
