### PR TITLE
Replace sox dependency with custom WAV file writer

### DIFF
--- a/README
+++ b/README
@@ -5,7 +5,6 @@ glib (for the core library)
 mad (for MP3 transfer, can be disabled)
 libmcrypt (for PCM transfer, can be disabled)
 Qt 4 (for the GUI)
-sox 14.2 (for the GUI)
 
 BUILDING
 

--- a/qhimdtransfer/main.cpp
+++ b/qhimdtransfer/main.cpp
@@ -13,7 +13,6 @@
 int main(int argc, char *argv[])
 {
     int status;
-    sox_format_init();
 
     QApplication a(argc, argv);
     QTranslator trans;
@@ -29,6 +28,5 @@ int main(int argc, char *argv[])
     QHiMDMainWindow w;
     w.show();
     status = a.exec();
-    sox_format_quit();
     return status;
 }

--- a/qhimdtransfer/qhimdmainwindow.h
+++ b/qhimdtransfer/qhimdmainwindow.h
@@ -9,10 +9,6 @@
 #include "qhimddetection.h"
 #include "qmdmodel.h"
 
-extern "C" {
-#include <sox.h>
-}
-
 namespace Ui
 {
     class QHiMDMainWindowClass;

--- a/qhimdtransfer/qhimdtransfer.pro
+++ b/qhimdtransfer/qhimdtransfer.pro
@@ -76,10 +76,13 @@ SOURCES += main.cpp \
 win32:SOURCES += qhimdwindetection.cpp
 else:SOURCES += qhimddummydetection.cpp
 RESOURCES += icons.qrc
-PKGCONFIG += sox \
-    taglib
+PKGCONFIG += taglib
 win32:LIBS += -lsetupapi \
     -lcfgmgr32
+
+SOURCES += wavefilewriter.cpp
+HEADERS += wavefilewriter.h
+
 win32:RC_FILE = qhimdtransfer.rc
 mac:ICON = qhimdtransfer.icns
 

--- a/qhimdtransfer/qmddevice.cpp
+++ b/qhimdtransfer/qmddevice.cpp
@@ -2,14 +2,12 @@
 #include <QMessageBox>
 #include <QApplication>
 #include <QFile>
+#include "wavefilewriter.h"
+
 #include <tlist.h>
 #include <fileref.h>
 #include <tfile.h>
 #include <tag.h>
-
-extern "C" {
-#include <sox.h>
-}
 
 /* common device members */
 QMDDevice::QMDDevice() : dev_type(NO_DEVICE)
@@ -530,67 +528,46 @@ QString QHiMDDevice::dumppcm(const QHiMDTrack &track, QString file)
 {
     struct himd_nonmp3stream str;
     struct himderrinfo status;
-    unsigned int len, i;
-    int left, right;
-    int clipcount;
+    unsigned int len;
     QString errmsg;
-    QFile f(file);
     const unsigned char * data;
-    sox_format_t * out;
-    sox_sample_t soxbuf [HIMD_MAX_PCMFRAME_SAMPLES * 2];
-    sox_signalinfo_t signal_out;
-
-    signal_out.channels = 2;
-    signal_out.length = 0;
-    signal_out.precision = 16;
-    signal_out.rate = 44100;
-
-    if(!(out = sox_open_write(file.toUtf8(), &signal_out, NULL, NULL, NULL, NULL)))
-        return tr("Error opening file for WAV output");
+    WaveFileWriter waveFile;
 
     if(!(errmsg = track.openNonMpegStream(&str)).isNull())
     {
-        f.remove();
         return tr("Error opening track: ") + status.statusmsg;
     }
 
-    while(himd_nonmp3stream_read_block(&str, &data, &len, NULL, &status) >= 0)
-    {
+    if (!waveFile.open(file, 44100, 16, 2)) {
+        return tr("Error opening file for WAV output");
+    }
 
-      for(i = 0; i < len/4; i++) {
-
-        left = data[i*4]*256+data[i*4+1];
-        right = data[i*4+2]*256+data[i*4+3];
-        if (left > 0x8000) left -= 0x10000;
-        if (right > 0x8000) right -= 0x10000;
-
-        soxbuf[i*2] = SOX_SIGNED_16BIT_TO_SAMPLE(left, clipcount);
-        soxbuf[i*2+1] = SOX_SIGNED_16BIT_TO_SAMPLE(right, clipcount);
-        (void)clipcount; /* suppess "is unused" warning */
-      }
-
-      if (sox_write(out, soxbuf, len/2) != len/2)
-      {
+    while (himd_nonmp3stream_read_block(&str, &data, &len, NULL, &status) >= 0) {
+        if (!waveFile.write_signed_big_endian(reinterpret_cast<const int16_t *>(data), len / 2)) {
             errmsg = tr("Error writing audio data");
             goto clean;
-      }
-      uploadDialog.blockTransferred();
-      QApplication::processEvents();
-      if(uploadDialog.upload_canceled())
-      {
+        }
+
+        uploadDialog.blockTransferred();
+        QApplication::processEvents();
+        if (uploadDialog.upload_canceled()) {
             errmsg = QString("upload aborted by the user");
             goto clean;
-      }
+        }
     }
-    if(status.status != HIMD_STATUS_AUDIO_EOF)
+
+    if (status.status != HIMD_STATUS_AUDIO_EOF) {
         errmsg = QString("Error reading audio data: ") + status.statusmsg;
+    }
 
 clean:
-    sox_close(out);
+    waveFile.close();
     himd_nonmp3stream_close(&str);
 
-    if(!errmsg.isNull())
-        f.remove();
+    if (!errmsg.isNull()) {
+        QFile(file).remove();
+    }
+
     return errmsg;
 }
 

--- a/qhimdtransfer/wavefilewriter.cpp
+++ b/qhimdtransfer/wavefilewriter.cpp
@@ -1,0 +1,153 @@
+
+/**
+ * wavfilewriter: Helper class to write .wav file headers
+ * Copyright (C) 2016 Thomas Perl <m@thp.io>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ **/
+
+#include "wavefilewriter.h"
+
+#include <QIODevice>
+#include <QtEndian>
+#include <QDebug>
+
+/**
+ * Based on the file format description at http://soundfile.sapp.org/doc/WaveFormat/
+ **/
+
+struct RIFFHeader {
+    char riff[4]; // "RIFF"
+    uint32_t total_size;
+    char format[4]; // "WAVE"
+};
+
+struct ChunkHeader {
+    char id[4]; // "fmt " for format chunk, "data" for samples
+    uint32_t size;
+};
+
+struct FormatChunk {
+    int16_t audioFormat;
+    uint16_t numChannels;
+    uint32_t sampleRate;
+    uint32_t bytesPerSecond;
+    uint16_t blockAlign;
+    uint16_t bitsPerSample;
+};
+
+WaveFileWriter::WaveFileWriter()
+    : output()
+    , updateSize(false)
+{
+}
+
+WaveFileWriter::~WaveFileWriter()
+{
+    close();
+}
+
+bool
+WaveFileWriter::open(const QString &filename, int sampleRate, int sampleSize, int channels)
+{
+    output.close();
+    output.setFileName(filename);
+    output.open(QIODevice::WriteOnly);
+
+    RIFFHeader hdr;
+    ChunkHeader chk;
+    FormatChunk fmt;
+
+    // RIFF header
+    memcpy(hdr.riff, "RIFF", 4);
+    hdr.total_size = 0; // To be filled later
+    memcpy(hdr.format, "WAVE", 4);
+    if ((size_t)output.write((char *)&hdr, sizeof(hdr)) != sizeof(hdr)) {
+        return false;
+    }
+
+    // Format chunk header
+    memcpy(chk.id, "fmt ", 4);
+    chk.size = qToLittleEndian(uint32_t(sizeof(fmt)));
+    if ((size_t)output.write((char *)&chk, sizeof(chk)) != sizeof(chk)) {
+        return false;
+    }
+
+    // Format chunk
+    fmt.audioFormat = qToLittleEndian(int16_t(1)); // PCM
+    fmt.numChannels = qToLittleEndian(uint32_t(channels));
+    fmt.sampleRate = qToLittleEndian(uint32_t(sampleRate));
+    fmt.bytesPerSecond = qToLittleEndian(uint32_t(channels * (sampleSize / 8) * sampleRate));
+    fmt.blockAlign = qToLittleEndian(uint32_t(channels * (sampleSize / 8)));
+    fmt.bitsPerSample = qToLittleEndian(uint32_t(sampleSize));
+    if ((size_t)output.write((char *)&fmt, sizeof(fmt)) != sizeof(fmt)) {
+        return false;
+    }
+
+    // Data chunk header
+    memcpy(chk.id, "data", 4);
+    chk.size = 0; // To be filled later
+    if ((size_t)output.write((char *)&chk, sizeof(chk)) != sizeof(chk)) {
+        return false;
+    }
+
+    updateSize = true;
+    return true;
+}
+
+bool
+WaveFileWriter::write_signed_big_endian(const int16_t *data, size_t samples)
+{
+    int16_t tmp[samples];
+    for (size_t i=0; i<samples; i++) {
+        tmp[i] = qToLittleEndian(qFromBigEndian(data[i]));
+    }
+    return ((size_t)output.write(reinterpret_cast<const char *>(tmp), sizeof(tmp)) == sizeof(tmp));
+}
+
+static bool
+updateU32LESizeField(QFile &file, size_t offset, uint32_t new_value)
+{
+    if (!file.seek(offset)) {
+        qWarning() << "Could not seek to update field";
+        return false;
+    }
+
+    // The "remaining" size is calculated from after the value (subtract offset + value size)
+    new_value = qToLittleEndian(new_value - (offset + sizeof(new_value)));
+    if ((size_t)file.write((char *)&new_value, sizeof(new_value)) != sizeof(new_value)) {
+        qWarning() << "Could not update field in file";
+        return false;
+    }
+
+    return true;
+}
+
+void
+WaveFileWriter::close()
+{
+    // File size in the RIFF header
+    size_t riff_header_offset = offsetof(RIFFHeader, total_size);
+    // Chunk size in the "data" chunk
+    size_t data_header_offset = sizeof(RIFFHeader) + sizeof(ChunkHeader) + sizeof(FormatChunk) + offsetof(ChunkHeader, size);
+
+    if (updateSize &&
+            updateU32LESizeField(output, riff_header_offset, output.size()) &&
+            updateU32LESizeField(output, data_header_offset, output.size())) {
+        updateSize = false;
+    }
+
+    output.close();
+}

--- a/qhimdtransfer/wavefilewriter.h
+++ b/qhimdtransfer/wavefilewriter.h
@@ -1,0 +1,43 @@
+
+/**
+ * wavfilewriter: Helper class to write .wav file headers
+ * Copyright (C) 2016 Thomas Perl <m@thp.io>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ **/
+
+#ifndef _WAVEFILEWRITER_H
+#define _WAVEFILEWRITER_H
+
+#include <QString>
+#include <QFile>
+
+#include <stdint.h>
+
+class WaveFileWriter {
+public:
+    WaveFileWriter();
+    ~WaveFileWriter();
+
+    bool open(const QString &filename, int sampleRate, int sampleSize, int channels);
+    bool write_signed_big_endian(const int16_t *data, size_t samples);
+    void close();
+
+private:
+    QFile output;
+    bool updateSize;
+};
+
+#endif /* _WAVEFILEWRITER_H */


### PR DESCRIPTION
The only reason sox is dragged in as dependency is to write out WAV files. This can be easily done with custom code, and will in turn reduce the build-dependencies for cross-compilation cases.

Since we always get the same format (44100 Hz / stereo / big-endian signed 16-bit samples), writing out the samples is just a matter of byte-swapping the incoming 16-bit values, no need to convert to `sox_sample_t` (32-bit values) and then back.

I have verified with a simple LPCM recording that the resulting WAV file written out is exactly the same byte-by-byte as the WAV file written out by the old SOX-based code.

Right now, this code lives in QHiMDTransfer and uses Qt classes, but we could later move this down to `libhimd` (just using stdio file access) and use it in `himdcli` (for the `dumpnonmp3` sub-command, to write LPCM tracks as WAV files) and QHiMDTransfer.
