### PR TITLE
Replace taglib dependency with simple ID3v1 writer

### DIFF
--- a/qhimdtransfer/qhimdtransfer.pro
+++ b/qhimdtransfer/qhimdtransfer.pro
@@ -76,8 +76,7 @@ SOURCES += main.cpp \
 win32:SOURCES += qhimdwindetection.cpp
 else:SOURCES += qhimddummydetection.cpp
 RESOURCES += icons.qrc
-PKGCONFIG += sox \
-    taglib
+PKGCONFIG += sox
 win32:LIBS += -lsetupapi \
     -lcfgmgr32
 win32:RC_FILE = qhimdtransfer.rc


### PR DESCRIPTION
Taglib was an undocumented dependency for QHiMDTransfer. It was used to tag MP3 files transferred (uploaded, i.e. MD→PC) from Hi-MD devices. Similar to #11, this makes it easier to cross-compile the code by removing a build-dependency that would have to be built and shipped otherwise (also, other code already uses libid3tag for reading MP3 tags).

While taglib presumably wrote both ID3v1 and ID3v2 tags, this solution only writes a simple ID3v1 tag, but for data retrieved from the Hi-MD, that's probably good enough.

I also decided to remove the tag comment `"*** imported from HiMD via QHiMDTransfer ***"` while I'm at it, since it's a bit annoying to have that attached to all files imported - this is not an oversight, but done on purpose ;)

This probably conflicts with #11, since both modify the .pro file and the include section at the top of qmddevice.cpp, but it's easy to fix that, since both changes just remove the pkg-config dependency and the header file inclusions of the respective libraries to be removed.
