### PR TITLE
Determine build date based on host os, not target

### DIFF
--- a/qhimdtransfer/qhimdtransfer.pro
+++ b/qhimdtransfer/qhimdtransfer.pro
@@ -19,9 +19,13 @@ VERSION = $$system(sh ../get_version.sh)
 VERSTR = '\\"$${VERSION}\\"'  # place quotes around the version string
 DEFINES += VER=\"$${VERSTR}\" # create a VER macro containing the version string
 
-# determine build date
-unix:BUILDDATE = $$system(date +%a\\ %m\\/%d\\/%Y)
-win32:BUILDDATE = $$system(date /T)
+# determine build date (Using QMAKE_HOST here to account for cross-compilation case)
+
+equals(QMAKE_HOST.os,Windows) {
+    BUILDDATE = $$system(date /T)
+} else {
+    BUILDDATE = $$system(date +%a\\ %m\\/%d\\/%Y)
+}
 
 BDATESTR = '\\"$${BUILDDATE}\\"'  # place quotes around the build date string
 DEFINES += BDATE=\"$${BDATESTR}\" # create a BDATE macro containing the build date string


### PR DESCRIPTION
The `date` command is run at QMake/build time. In the cross-compilation (e.g. compiling Windows binaries on Linux) case, `win32` will be true, but the system on which `qmake` runs will be Linux.

Explicitly check whether QMake is running on Windows, and assume Unix in any other case, so that Windows binaries built on Linux will use the Unix variant of calling `date` at build time.
