### PR TITLE
Remove unused dependency on id3tag from netmdcli

### DIFF
--- a/netmdcli/netmdcli.pro
+++ b/netmdcli/netmdcli.pro
@@ -1,7 +1,7 @@
 TEMPLATE=app
 CONFIG  -= qt
 CONFIG  += console link_pkgconfig link_prl
-PKGCONFIG += glib-2.0 id3tag libusb-1.0
+PKGCONFIG += glib-2.0 libusb-1.0
 INCLUDEPATH += ../libnetmd
 SOURCES += netmdcli.c
 


### PR DESCRIPTION
libid3tag is only used in `libhimd` and `himdcli`, there's no need to link `netmdcli` (which does not link against `libhimd`) against libid3tag.

```
% ag id3tag
himdcli/himdcli.c
11:#include <id3tag.h>

himdcli/himdcli.pro
4:PKGCONFIG += glib-2.0 id3tag

libhimd/mp3tools.c
26:#include <id3tag.h>

qhimdtransfer/qmddevice.cpp
464:static void addid3tag(QString title, QString artist, QString album, QString file)
621:                addid3tag (track.title(),track.artist(),track.album(), path + "/" +filename + ".mp3");
```
