### PR TITLE
libnetmd chunksize fix

### DIFF
--- a/libnetmd/secure.c
+++ b/libnetmd/secure.c
@@ -381,7 +381,10 @@ void netmd_transfer_song_packets(netmd_dev_handle *dev,
         if (error >= 0) {
             p = p->next;
         }
-        break;
+        else {
+            /* error transfering data */
+            break;
+        }
     }
 }
 
@@ -391,7 +394,7 @@ netmd_error netmd_prepare_packets(unsigned char* data, size_t data_lenght,
                                   unsigned char *key_encryption_key)
 {
     size_t position = 0;
-    size_t chunksize = 0xffffffffU;
+    size_t chunksize = 0x000fffffU;
     netmd_track_packets *last = NULL;
     netmd_track_packets *next = NULL;
 

--- a/libnetmd/secure.c
+++ b/libnetmd/secure.c
@@ -378,13 +378,11 @@ void netmd_transfer_song_packets(netmd_dev_handle *dev,
         free(packet);
         buf = NULL;
 
-        if (error >= 0) {
-            p = p->next;
-        }
-        else {
-            /* error transfering data */
+        if (error < 0) {
             break;
         }
+        
+        p = p->next;
     }
 }
 
@@ -394,7 +392,7 @@ netmd_error netmd_prepare_packets(unsigned char* data, size_t data_lenght,
                                   unsigned char *key_encryption_key)
 {
     size_t position = 0;
-    size_t chunksize = 0x000fffffU;
+    size_t chunksize = 0x00180000U;
     netmd_track_packets *last = NULL;
     netmd_track_packets *next = NULL;
 


### PR DESCRIPTION
- Using a smaller chunksize (~1Mb)
- Fixed a missing 'else' scope which prevented trackdata to be splited in several packets
