### PR TITLE
Force remaining size value to be unsigned 32-bit (Fixes #23)

### DIFF
--- a/qhimdtransfer/wavefilewriter.cpp
+++ b/qhimdtransfer/wavefilewriter.cpp
@@ -126,7 +126,7 @@ updateU32LESizeField(QFile &file, size_t offset, uint32_t new_value)
     }
 
     // The "remaining" size is calculated from after the value (subtract offset + value size)
-    new_value = qToLittleEndian(new_value - (offset + sizeof(new_value)));
+    new_value = qToLittleEndian(uint32_t(new_value - (offset + sizeof(new_value))));
     if ((size_t)file.write((char *)&new_value, sizeof(new_value)) != sizeof(new_value)) {
         qWarning() << "Could not update field in file";
         return false;


### PR DESCRIPTION
Offset is `size_t` and `sizeof()` is `size_t`, which is fine on 32-bit platforms, but not on 64-bit platforms; force the parameter of `qToLittleEndian()` to be `uint32_t`, so we get sane results.

This only affected big-endian 64-bit archs (i.e. didn't affect amd64), since `qToLittleEndian()` is a no-op on little endian archs.