### PR TITLE
Remove glib dependency for libnetmd/netmdcli/qhimdtransfer

### DIFF
--- a/libnetmd/libnetmd.pro
+++ b/libnetmd/libnetmd.pro
@@ -9,5 +9,4 @@ SOURCES += common.c error.c libnetmd.c log.c netmd_dev.c playercontrol.c secure.
 
 include(../build/libgcrypt.pri)
 include(../build/libusb.pri)
-include(../build/libglib.pri)
 include(../build/common.pri)

--- a/netmdcli/netmdcli.pro
+++ b/netmdcli/netmdcli.pro
@@ -5,6 +5,5 @@ SOURCES += netmdcli.c
 
 include(../libnetmd/use_libnetmd.prl)
 include(../build/libusb.pri)
-include(../build/libglib.pri)
 include(../build/installunix.pri)
 include(../build/common.pri)

--- a/qhimdtransfer/qhimdtransfer.pro
+++ b/qhimdtransfer/qhimdtransfer.pro
@@ -106,7 +106,6 @@ unix {
 
 include(../libhimd/use_libhimd.pri)
 include(../libnetmd/use_libnetmd.prl)
-include(../build/libglib.pri)
 include(../build/libusb.pri)
 include(../build/libtaglib.pri)
 include(../build/installunix.pri)


### PR DESCRIPTION
We don't link against those libraries, maybe we don't need them there.