### PR TITLE
Fix out-of-bounds access in netmd_request_title() (Contributes to #47)

### DIFF
--- a/libnetmd/trackinformation.c
+++ b/libnetmd/trackinformation.c
@@ -113,15 +113,18 @@ int netmd_request_title(netmd_dev_handle* dev, const uint16_t track, char* buffe
     if(title_size == 0 || title_size == 0x13)
         return -1; /* bail early somethings wrong or no track */
 
-    if(title_size > size)
+    int title_response_header_size = 25;
+    const char *title_text = title + title_response_header_size;
+    size_t required_size = title_size - title_response_header_size;
+
+    if (required_size > size - 1)
     {
         printf("netmd_request_title: title too large for buffer\n");
         return -1;
     }
 
     memset(buffer, 0, size);
-    memcpy(buffer, (title + 25), title_size - 25);
-    buffer[size] = 0;
+    memcpy(buffer, title_text, required_size);
 
-    return (int)title_size - 25;
+    return required_size;
 }


### PR DESCRIPTION
QHiMDTransfer crashed when trying to access a NetMD device (see #47):

In `QNetMDDevice::open()`, there is a buffer allocated on the stack:

    char buffer[256];

This buffer is used to request title information to find out the
number of tracks on the NetMD device:

    while(netmd_request_title(devh, i, buffer, sizeof(buffer)) >= 0)

Then, in `libnetmd/trackinformation.c`, in `netmd_request_title()`, at
the end of the function, the byte after this buffer is touched:

    buffer[size] = 0;

Work around this by cleaning up the limit calculation a bit and only
writing up to `size-1` bytes from the title to the buffer (so there is
always a trailing `'\0'`).

In case of #47, this was running on macOS, so it probably had enough stack protection built in to detect that issue (that probably existed for a long time).