### PR TITLE
Adds support for the MZ-M10 in both NetMD and Hi-MD modes

### DIFF
--- a/libnetmd/netmd_dev.c
+++ b/libnetmd/netmd_dev.c
@@ -64,7 +64,7 @@ static struct netmd_devices const known_devices[] =
     {0x54c, 0x18a}, /* Sony LAM-3 */
     {0x54c, 0x1e9}, /* Sony MZ-DH10P */
     {0x54c, 0x219}, /* Sony MZ-RH10 */
-    {0x54c, 0x21b}, /* Sony MZ-RH910 */
+    {0x54c, 0x21b}, /* Sony MZ-RH910/M10 */
     {0x54c, 0x21d}, /* Sony CMT-AH10 */
     {0x54c, 0x22c}, /* Sony CMT-AH10 */
     {0x54c, 0x23c}, /* Sony DS-HMD1 */

--- a/netmd/libnetmd.py
+++ b/netmd/libnetmd.py
@@ -52,7 +52,7 @@ KNOWN_USB_ID_SET = frozenset([
     (0x054c, 0x018a), # Sony LAM-3
     (0x054c, 0x01e9), # Sony MZ-DH10P
     (0x054c, 0x0219), # Sony MZ-RH10
-    (0x054c, 0x021b), # Sony MZ-RH710/MZ-RH910
+    (0x054c, 0x021b), # Sony MZ-RH710/MZ-RH910/MZ-M10
     (0x054c, 0x022c), # Sony CMT-AH10 (stereo set with integrated MD)
     (0x054c, 0x023c), # Sony DS-HMD1 (device without analog music rec/playback)
     (0x054c, 0x0286), # Sony MZ-RH1

--- a/qhimdtransfer/qhimddetection.cpp
+++ b/qhimdtransfer/qhimddetection.cpp
@@ -191,7 +191,7 @@ const char * identify_usb_device(int vid, int pid)
         case MZ_RH10_HIMD:
             return "SONY MZ-RH10";
         case MZ_RH910_HIMD:
-            return "SONY MZ-RH910";
+            return "SONY MZ-RH910 / MZ-M10";
         case CMT_AH10_HIMD:
             return "SONY CMT-AH10";
         case DS_HMD1_HIMD:
@@ -261,7 +261,7 @@ const char * identify_usb_device(int vid, int pid)
         case MZ_RH10:
             return "SONY MZ-RH10 (NetMD)";
         case MZ_RH910:
-            return "SONY MZ-RH910 (NetMD)";
+            return "SONY MZ-RH910 / MZ-M10 (NetMD)";
         case CMT_AH10_A:
             return "SONY CMT-AH10 (NetMD)";
         case CMT_AH10_B:

--- a/qhimdtransfer/qhimddetection.h
+++ b/qhimdtransfer/qhimddetection.h
@@ -19,7 +19,7 @@
 #define LAM_3_HIMD 0x018b
 #define MZ_DH10P_HIMD 0x01ea
 #define MZ_RH10_HIMD 0x021a
-#define MZ_RH910_HIMD 0x021c
+#define MZ_RH910_HIMD 0x021c       // or MZ-M10
 #define CMT_AH10_HIMD 0x022d
 #define DS_HMD1_HIMD 0x023d
 #define MZ_RH1_HIMD 0x0287
@@ -56,7 +56,7 @@
 #define LAM_3 0x18a
 #define MZ_DH10P 0x1e9
 #define MZ_RH10 0x219
-#define MZ_RH910 0x21b
+#define MZ_RH910 0x21b             // or MZ-M10
 #define CMT_AH10_A 0x21d
 #define CMT_AH10_B 0x22c
 #define DS_HMD1 0x23c


### PR DESCRIPTION
The [MZ-M10 is the slightly more rare "Macintosh" variant of the MZ-RH910](http://www.minidisc.org/part_Sony_MZ-M10+RH910.html). It can be distinguished by its slightly different case finish (black body, silver border, black navigation wheel and track transport buttons). It appears identically to the MZ-RH910 over USB.

This patch adds the MZ-M10 to the identifiers for future convenience, and so that QHiMDTransfer additionally shows the M10 designation in the device dropdown.

For your reference, I've pulled the USB identifiers from my Mac's System Information.

In Hi-MD mode:

    Hi-MD:

      Product ID: 0x021c
      Vendor ID:  0x054c  (Sony Corporation)
      Version:  1.00
      Serial Number:  0200011069AB
      Speed:  Up to 12 Mb/sec
      Manufacturer: Sony
      Location ID:  0x14500000 / 12
      Current Available (mA): 500
      Current Required (mA):  500
      Extra Operating Current (mA): 0

And in NetMD mode:

    Net MD/Hi-MD:

      Product ID: 0x021b
      Vendor ID:  0x054c  (Sony Corporation)
      Version:  1.00
      Serial Number:  0200011069AB
      Speed:  Up to 12 Mb/sec
      Manufacturer: Sony
      Location ID:  0x14500000 / 15
      Current Available (mA): 500
      Current Required (mA):  500
      Extra Operating Current (mA): 0