### PR TITLE
lsmd: decode Shift JIS from halfwidth titles

### DIFF
--- a/netmd/lsmd.py
+++ b/netmd/lsmd.py
@@ -63,7 +63,7 @@ def listMD(md, show_uuids):
             print '%s%03i: %02i:%02i:%02i+%03i %s %s %s %s %s' % (prefix,
                 track, hour, minute, second, sample, codec_name_dict[codec],
                 channel_count_dict[channel_count], flag_dict[flags],
-                md_iface.getTrackTitle(real_track),
+                md_iface.getTrackTitle(real_track).decode('shift_jis_2004'),
                 md_iface.getTrackTitle(real_track, True).decode('shift_jis_2004'))
             if show_uuids:
                 uuid = md_iface.getTrackUUID(real_track)


### PR DESCRIPTION
Japanese minidiscs can contain single-byte characters in this field. I found this on a disc that had track titles written exclusively using single-byte katakana. That means it's not safe to print this field without decoding it, too.