### PR TITLE
libnetmd: Handle encoding and decoding of track and disc titles

### DIFF
--- a/libnetmd/const.h
+++ b/libnetmd/const.h
@@ -83,4 +83,9 @@
 
 #define NETMD_RIFF_FORMAT_TAG_ATRAC3 0x270
 
+/**
+   NetMD disc and track title responses' header size
+ */
+#define NETMD_TITLE_RESPONSE_HEADER_SIZE 25
+
 #endif

--- a/libnetmd/kataconv.c
+++ b/libnetmd/kataconv.c
@@ -204,7 +204,7 @@ kata_full_to_half(uint8_t* input)
     convert(input, FULL_HEAD, FULL_TAIL, HALF_HEAD, HALF_TAIL);
 }
 
-// rewrites full-width katakana to half-width in place
+// rewrites half-width katakana to full-width in place
 void
 kata_half_to_full(uint8_t* input)
 {

--- a/libnetmd/kataconv.c
+++ b/libnetmd/kataconv.c
@@ -21,7 +21,7 @@
  *
  */
 
-#include <stdint.h>
+#include "kataconv.h"
 
 struct tail {
     uint8_t a;

--- a/libnetmd/kataconv.c
+++ b/libnetmd/kataconv.c
@@ -1,0 +1,212 @@
+/*
+ * kataconv.c
+ *
+ * This file is part of libnetmd, a library for accessing Sony NetMD devices.
+ *
+ * Copyright (C) 2020 Charlie Somerville
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include <stdint.h>
+
+struct tail {
+    uint8_t a;
+    uint8_t b;
+};
+
+static const uint8_t FULL_HEAD = 0xe3;
+
+// second and third bytes of each full-width katakana
+// the first byte is always 0xe3, so we don't need to include it in this list
+static const struct tail FULL_TAIL[] = {
+    { 0x80, 0x81 }, // "、"
+    { 0x80, 0x82 }, // "。"
+    { 0x80, 0x8c }, // "「"
+    { 0x80, 0x8d }, // "」"
+    { 0x82, 0x9b }, // "゛"
+    { 0x82, 0x9c }, // "゜"
+    { 0x82, 0xa1 }, // "ァ"
+    { 0x82, 0xa2 }, // "ア"
+    { 0x82, 0xa3 }, // "ィ"
+    { 0x82, 0xa4 }, // "イ"
+    { 0x82, 0xa5 }, // "ゥ"
+    { 0x82, 0xa6 }, // "ウ"
+    { 0x82, 0xa7 }, // "ェ"
+    { 0x82, 0xa8 }, // "エ"
+    { 0x82, 0xa9 }, // "ォ"
+    { 0x82, 0xaa }, // "オ"
+    { 0x82, 0xab }, // "カ"
+    { 0x82, 0xad }, // "キ"
+    { 0x82, 0xaf }, // "ク"
+    { 0x82, 0xb1 }, // "ケ"
+    { 0x82, 0xb3 }, // "コ"
+    { 0x82, 0xb5 }, // "サ"
+    { 0x82, 0xb7 }, // "シ"
+    { 0x82, 0xb9 }, // "ス"
+    { 0x82, 0xbb }, // "セ"
+    { 0x82, 0xbd }, // "ソ"
+    { 0x82, 0xbf }, // "タ"
+    { 0x83, 0x81 }, // "チ"
+    { 0x83, 0x83 }, // "ッ"
+    { 0x83, 0x84 }, // "ツ"
+    { 0x83, 0x86 }, // "テ"
+    { 0x83, 0x88 }, // "ト"
+    { 0x83, 0x8a }, // "ナ"
+    { 0x83, 0x8b }, // "ニ"
+    { 0x83, 0x8c }, // "ヌ"
+    { 0x83, 0x8d }, // "ネ"
+    { 0x83, 0x8e }, // "ノ"
+    { 0x83, 0x8f }, // "ハ"
+    { 0x83, 0x92 }, // "ヒ"
+    { 0x83, 0x95 }, // "フ"
+    { 0x83, 0x98 }, // "ヘ"
+    { 0x83, 0x9b }, // "ホ"
+    { 0x83, 0x9e }, // "マ"
+    { 0x83, 0x9f }, // "ミ"
+    { 0x83, 0xa0 }, // "ム"
+    { 0x83, 0xa1 }, // "メ"
+    { 0x83, 0xa2 }, // "モ"
+    { 0x83, 0xa3 }, // "ャ"
+    { 0x83, 0xa4 }, // "ヤ"
+    { 0x83, 0xa5 }, // "ュ"
+    { 0x83, 0xa6 }, // "ユ"
+    { 0x83, 0xa7 }, // "ョ"
+    { 0x83, 0xa8 }, // "ヨ"
+    { 0x83, 0xa9 }, // "ラ"
+    { 0x83, 0xaa }, // "リ"
+    { 0x83, 0xab }, // "ル"
+    { 0x83, 0xac }, // "レ"
+    { 0x83, 0xad }, // "ロ"
+    { 0x83, 0xaf }, // "ワ"
+    { 0x83, 0xb2 }, // "ヲ"
+    { 0x83, 0xb3 }, // "ン"
+    { 0x83, 0xbb }, // "・"
+    { 0x83, 0xbc }, // "ー"
+    { 0, 0 }, // end
+};
+
+static const uint8_t HALF_HEAD = 0xef;
+
+// same as FULL_TAIL, but for the half width forms.
+static const struct tail HALF_TAIL[] = {
+    { 0xbd, 0xa4 }, // "､"
+    { 0xbd, 0xa1 }, // "｡"
+    { 0xbd, 0xa2 }, // "｢"
+    { 0xbd, 0xa3 }, // "｣"
+    { 0xbe, 0x9e }, // "ﾞ"
+    { 0xbe, 0x9f }, // "ﾟ"
+    { 0xbd, 0xa7 }, // "ｧ"
+    { 0xbd, 0xb1 }, // "ｱ"
+    { 0xbd, 0xa8 }, // "ｨ"
+    { 0xbd, 0xb2 }, // "ｲ"
+    { 0xbd, 0xa9 }, // "ｩ"
+    { 0xbd, 0xb3 }, // "ｳ"
+    { 0xbd, 0xaa }, // "ｪ"
+    { 0xbd, 0xb4 }, // "ｴ"
+    { 0xbd, 0xab }, // "ｫ"
+    { 0xbd, 0xb5 }, // "ｵ"
+    { 0xbd, 0xb6 }, // "ｶ"
+    { 0xbd, 0xb7 }, // "ｷ"
+    { 0xbd, 0xb8 }, // "ｸ"
+    { 0xbd, 0xb9 }, // "ｹ"
+    { 0xbd, 0xba }, // "ｺ"
+    { 0xbd, 0xbb }, // "ｻ"
+    { 0xbd, 0xbc }, // "ｼ"
+    { 0xbd, 0xbd }, // "ｽ"
+    { 0xbd, 0xbe }, // "ｾ"
+    { 0xbd, 0xbf }, // "ｿ"
+    { 0xbe, 0x80 }, // "ﾀ"
+    { 0xbe, 0x81 }, // "ﾁ"
+    { 0xbd, 0xaf }, // "ｯ"
+    { 0xbe, 0x82 }, // "ﾂ"
+    { 0xbe, 0x83 }, // "ﾃ"
+    { 0xbe, 0x84 }, // "ﾄ"
+    { 0xbe, 0x85 }, // "ﾅ"
+    { 0xbe, 0x86 }, // "ﾆ"
+    { 0xbe, 0x87 }, // "ﾇ"
+    { 0xbe, 0x88 }, // "ﾈ"
+    { 0xbe, 0x89 }, // "ﾉ"
+    { 0xbe, 0x8a }, // "ﾊ"
+    { 0xbe, 0x8b }, // "ﾋ"
+    { 0xbe, 0x8c }, // "ﾌ"
+    { 0xbe, 0x8d }, // "ﾍ"
+    { 0xbe, 0x8e }, // "ﾎ"
+    { 0xbe, 0x8f }, // "ﾏ"
+    { 0xbe, 0x90 }, // "ﾐ"
+    { 0xbe, 0x91 }, // "ﾑ"
+    { 0xbe, 0x92 }, // "ﾒ"
+    { 0xbe, 0x93 }, // "ﾓ"
+    { 0xbd, 0xac }, // "ｬ"
+    { 0xbe, 0x94 }, // "ﾔ"
+    { 0xbd, 0xad }, // "ｭ"
+    { 0xbe, 0x95 }, // "ﾕ"
+    { 0xbd, 0xae }, // "ｮ"
+    { 0xbe, 0x96 }, // "ﾖ"
+    { 0xbe, 0x97 }, // "ﾗ"
+    { 0xbe, 0x98 }, // "ﾘ"
+    { 0xbe, 0x99 }, // "ﾙ"
+    { 0xbe, 0x9a }, // "ﾚ"
+    { 0xbe, 0x9b }, // "ﾛ"
+    { 0xbe, 0x9c }, // "ﾜ"
+    { 0xbd, 0xa6 }, // "ｦ"
+    { 0xbe, 0x9d }, // "ﾝ"
+    { 0xbd, 0xa5 }, // "･"
+    { 0xbd, 0xb0 }, // "ｰ"
+    { 0, 0 }, // end
+};
+
+static void
+convert(uint8_t* input, uint8_t from_head, const struct tail* const from, uint8_t to_head, const struct tail* const to)
+{
+    for (; *input; input++) {
+        if (*input == from_head) {
+            const struct tail* from_i = from;
+            const struct tail* to_i = to;
+
+            // bounds check:
+            if (input[1] == 0 || input[2] == 0) {
+                // whoops, the string terminates early. leave it as-is
+                return;
+            }
+
+            // search for this character in the conversion map
+            for (; from_i->a; from_i++, to_i++) {
+                if (from_i->a == input[1] && from_i->b == input[2]) {
+                    input[0] = to_head;
+                    input[1] = to_i->a;
+                    input[2] = to_i->b;
+                    input += 2;
+                    break;
+                }
+            }
+        }
+    }
+}
+
+// rewrites full-width katakana to half-width in place
+void
+kata_full_to_half(uint8_t* input)
+{
+    convert(input, FULL_HEAD, FULL_TAIL, HALF_HEAD, HALF_TAIL);
+}
+
+// rewrites full-width katakana to half-width in place
+void
+kata_half_to_full(uint8_t* input)
+{
+    convert(input, HALF_HEAD, HALF_TAIL, FULL_HEAD, FULL_TAIL);
+}

--- a/libnetmd/kataconv.h
+++ b/libnetmd/kataconv.h
@@ -1,0 +1,20 @@
+#ifndef LIBNETMD_KATACONV_H
+#define LIBNETMD_KATACONV_H
+
+#include <stdint.h>
+
+/**
+   Rewrite full-width katakana to half-width in place.
+
+   @param input pointer to UTF-8 encoded string to convert
+*/
+void kata_full_to_half(uint8_t* input);
+
+/**
+   Rewrite half-width katakana to full-width in place.
+
+   @param input pointer to UTF-8 encoded string to convert
+*/
+void kata_half_to_full(uint8_t* input);
+
+#endif

--- a/libnetmd/libnetmd.c
+++ b/libnetmd/libnetmd.c
@@ -109,7 +109,7 @@ static int request_disc_title_raw(netmd_dev_handle* dev, char* buffer, size_t si
     }
 
     unsigned char title_request[] = {0x00, 0x18, 0x06, 0x02, 0x20, 0x18,
-                                     0x01, encoding, 0x00, 0x30, 0x00, 0x0a,
+                                     0x01, 0x00, encoding, 0x30, 0x00, 0x0a,
                                      0x00, 0xff, 0x00, 0x00, 0x00, 0x00,
                                      0x00};
     unsigned char title[255];

--- a/libnetmd/libnetmd.c
+++ b/libnetmd/libnetmd.c
@@ -665,8 +665,6 @@ int netmd_set_disc_title_raw(netmd_dev_handle* dev, char* title, size_t title_le
     if(oldsize == -1)
         oldsize = 0; /* Reading failed -> no title at all, replace 0 bytes */
 
-    printf("netmd_set_disc_title_raw: oldsize = %d\n", oldsize);
-
     request = malloc(21 + title_length);
     memset(request, 0, 21 + title_length);
 

--- a/libnetmd/libnetmd.c
+++ b/libnetmd/libnetmd.c
@@ -25,6 +25,7 @@
 #include <unistd.h>
 #include <glib.h>
 
+#include "kataconv.h"
 #include "libnetmd.h"
 #include "utils.h"
 
@@ -130,6 +131,8 @@ static int request_disc_title(netmd_dev_handle* dev, char* buffer, size_t size)
         printf("request_disc_title: title couldn't be converted from JIS_X0201 to UTF-8: %s\n", err->message);
         return -1;
     }
+
+    kata_half_to_full((uint8_t*)decoded_title_text);
 
     size_t decoded_title_size = strlen(decoded_title_text);
 

--- a/libnetmd/libnetmd.c
+++ b/libnetmd/libnetmd.c
@@ -162,7 +162,7 @@ static int request_disc_title(netmd_dev_handle* dev, char* buffer, size_t size)
 
     // if the narrow title is zero-length, request the wide (Shift JIS) disc title
     if (title_text_size == 0) {
-        ret = request_disc_title_raw(dev, title, size, false);
+        ret = request_disc_title_raw(dev, title, size, true);
         if(ret < 0)
         {
             return 0;

--- a/libnetmd/libnetmd.c
+++ b/libnetmd/libnetmd.c
@@ -24,6 +24,7 @@
 
 #include <unistd.h>
 #include <glib.h>
+#include <stdbool.h>
 
 #include "kataconv.h"
 #include "libnetmd.h"
@@ -97,21 +98,26 @@ static unsigned char* sendcommand(netmd_dev_handle* devh, unsigned char* str, co
     return buf;
 }
 
-static int request_disc_title(netmd_dev_handle* dev, char* buffer, size_t size)
+static int request_disc_title_raw(netmd_dev_handle* dev, char* buffer, size_t size, bool wide_chars)
 {
     int ret = -1;
     size_t title_response_size = 0;
+
+    unsigned char encoding = 0x00;
+    if (wide_chars) {
+        encoding = 0x01;
+    }
+
     unsigned char title_request[] = {0x00, 0x18, 0x06, 0x02, 0x20, 0x18,
-                                     0x01, 0x00, 0x00, 0x30, 0x00, 0xa,
+                                     0x01, encoding, 0x00, 0x30, 0x00, 0x0a,
                                      0x00, 0xff, 0x00, 0x00, 0x00, 0x00,
                                      0x00};
     unsigned char title[255];
-    GError * err = NULL;
 
     ret = netmd_exch_message(dev, title_request, 0x13, title);
     if(ret < 0)
     {
-        fprintf(stderr, "request_disc_title: bad ret code, returning early\n");
+        fprintf(stderr, "request_disc_title_raw: bad ret code, returning early\n");
         return 0;
     }
 
@@ -122,17 +128,68 @@ static int request_disc_title(netmd_dev_handle* dev, char* buffer, size_t size)
 
     int title_response_header_size = 25;
     const char *title_text = title + title_response_header_size;
-    size_t encoded_title_size = title_response_size - title_response_header_size;
+    size_t title_size = title_response_size - title_response_header_size;
 
-    char * decoded_title_text = g_convert(title_text, encoded_title_size, "UTF-8", "JIS_X0201", NULL, NULL, &err);
-
-    if(err)
+    if(title_size >= size)
     {
-        printf("request_disc_title: title couldn't be converted from JIS_X0201 to UTF-8: %s\n", err->message);
+        printf("request_disc_title_raw: title too large for buffer\n");
         return -1;
     }
 
-    kata_half_to_full((uint8_t*)decoded_title_text);
+    memset(buffer, 0, size);
+    memcpy(buffer, title_text, title_size);
+
+    return title_response_size;
+}
+
+static int request_disc_title(netmd_dev_handle* dev, char* buffer, size_t size)
+{
+    int ret = -1;
+    size_t title_text_size = 0;
+    char title[255];
+    GError * err = NULL;
+
+    // request the narrow (JIS X0201) disc title
+    ret = request_disc_title_raw(dev, title, size, false);
+    if(ret < 0)
+    {
+        return 0;
+    }
+
+    title_text_size = (size_t)ret;
+
+    char * decoded_title_text;
+
+    // if the narrow title is zero-length, request the wide (Shift JIS) disc title
+    if (title_text_size == 0) {
+        ret = request_disc_title_raw(dev, title, size, false);
+        if(ret < 0)
+        {
+            return 0;
+        }
+
+        title_text_size = (size_t)ret;
+
+        // convert the Shift JIS disc title to UTF-8
+        decoded_title_text = g_convert(title, title_text_size, "UTF-8", "SHIFT_JIS", NULL, NULL, &err);
+
+        if(err)
+        {
+            printf("request_disc_title: title couldn't be converted from SHIFT_JIS to UTF-8: %s\n", err->message);
+            return -1;
+        }
+    } else {
+        // convert the JIS X0201 disc title to UTF-8
+        decoded_title_text = g_convert(title, title_text_size, "UTF-8", "JIS_X0201", NULL, NULL, &err);
+
+        if(err)
+        {
+            printf("request_disc_title: title couldn't be converted from JIS_X0201 to UTF-8: %s\n", err->message);
+            return -1;
+        }
+
+        kata_half_to_full((uint8_t*)decoded_title_text);
+    }
 
     size_t decoded_title_size = strlen(decoded_title_text);
 
@@ -146,7 +203,7 @@ static int request_disc_title(netmd_dev_handle* dev, char* buffer, size_t size)
     memcpy(buffer, decoded_title_text, decoded_title_size);
     g_free(decoded_title_text);
 
-    return title_response_size;
+    return title_text_size;
 }
 
 int netmd_request_track_time(netmd_dev_handle* dev, const uint16_t track, struct netmd_track* buffer)

--- a/libnetmd/libnetmd.c
+++ b/libnetmd/libnetmd.c
@@ -200,6 +200,8 @@ int netmd_set_title(netmd_dev_handle* dev, const uint16_t track, const char* con
 
     size = strlen(buffer);
 
+    kata_full_to_half((uint8_t*)buffer);
+
     char * encoded_title_text = g_convert(buffer, size, "JIS_X0201", "UTF-8", NULL, NULL, &err);
 
     if(err)
@@ -510,6 +512,8 @@ int netmd_set_disc_title(netmd_dev_handle* dev, char* title, size_t title_length
     oldsize = request_disc_title(dev, (char *)reply, sizeof(reply));
     if(oldsize == -1)
         oldsize = 0; /* Reading failed -> no title at all, replace 0 bytes */
+
+    kata_full_to_half((uint8_t*)title);
 
     char * encoded_title_text = g_convert(title, title_length, "JIS_X0201", "UTF-8", NULL, NULL, &err);
 

--- a/libnetmd/libnetmd.h
+++ b/libnetmd/libnetmd.h
@@ -31,6 +31,7 @@
 #include <string.h>
 #include <errno.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 #include <libusb.h>
 
@@ -105,6 +106,9 @@ int netmd_request_track_time(netmd_dev_handle* dev, const uint16_t track, struct
 /**
    Sets title for the specified track.
 
+   Titles set using this function are converted from
+   UTF-8 for your convenience.
+
    @param dev pointer to device returned by netmd_open
    @param track Zero based index of track your requesting.
    @param buffer buffer to hold the name.
@@ -113,7 +117,25 @@ int netmd_request_track_time(netmd_dev_handle* dev, const uint16_t track, struct
 int netmd_set_title(netmd_dev_handle* dev, const uint16_t track, const char* const buffer);
 
 /**
-   Sets title for the specified track.
+   Sets raw title for the specified track.
+
+   Narrow titles are expected to be raw JIS X0201 text,
+   wide titles are expected to be raw Shift JIS text.
+   A given MiniDisc track may only have one set.
+
+   For automatic selection, and UTF-8 conversion,
+   please use netmd_set_title instead.
+
+   @param dev pointer to device returned by netmd_open
+   @param track Zero based index of track your requesting.
+   @param buffer buffer to hold the name.
+   @param whether to set the narrow or wide title.
+   @return returns 0 for fail 1 for success.
+*/
+int netmd_set_title_raw(netmd_dev_handle* dev, const uint16_t track, const char* const buffer, bool wide_chars);
+
+/**
+   Sets title for the specified group.
 
    @param dev pointer to device returned by netmd_open
    @param md pointer to minidisc structure

--- a/libnetmd/libnetmd.h
+++ b/libnetmd/libnetmd.h
@@ -109,12 +109,43 @@ int netmd_request_track_time(netmd_dev_handle* dev, const uint16_t track, struct
    Titles set using this function are converted from
    UTF-8 for your convenience.
 
+   Note that this function will automatically choose the
+   most appropriate title field to use, and clear the other.
+   For specific control over the wide and narrow title fields,
+   please use netmd_set_title_narrow and netmd_set_title_wide.
+
    @param dev pointer to device returned by netmd_open
    @param track Zero based index of track your requesting.
    @param buffer buffer to hold the name.
    @return returns 0 for fail 1 for success.
 */
 int netmd_set_title(netmd_dev_handle* dev, const uint16_t track, const char* const buffer);
+
+/**
+   Sets narrow (JIS X0201) title for the specified track.
+
+   Titles set using this function are converted from
+   UTF-8 for your convenience.
+
+   @param dev pointer to device returned by netmd_open
+   @param track Zero based index of track your requesting.
+   @param buffer buffer to hold the name.
+   @return returns -1 if text couldn't be converted, 0 for failure, and 1 for success.
+*/
+int netmd_set_title_narrow(netmd_dev_handle* dev, const uint16_t track, const char* const buffer);
+
+/**
+   Sets wide (Shift JIS) title for the specified track.
+
+   Titles set using this function are converted from
+   UTF-8 for your convenience.
+
+   @param dev pointer to device returned by netmd_open
+   @param track Zero based index of track your requesting.
+   @param buffer buffer to hold the name.
+   @return returns -1 if text couldn't be converted, 0 for failure, and 1 for success.
+*/
+int netmd_set_title_wide(netmd_dev_handle* dev, const uint16_t track, const char* const buffer);
 
 /**
    Sets raw title for the specified track.

--- a/libnetmd/libnetmd.pro
+++ b/libnetmd/libnetmd.pro
@@ -9,4 +9,5 @@ SOURCES += common.c error.c libnetmd.c log.c netmd_dev.c playercontrol.c secure.
 
 include(../build/libgcrypt.pri)
 include(../build/libusb.pri)
+include(../build/libglib.pri)
 include(../build/common.pri)

--- a/libnetmd/libnetmd.pro
+++ b/libnetmd/libnetmd.pro
@@ -4,8 +4,8 @@ CONFIG -= qt
 CONFIG += staticlib link_pkgconfig create_prl console debug_and_release_target
 
 HEADERS += common.h const.h error.h libnetmd.h log.h netmd_dev.h playercontrol.h secure.h trackinformation.h utils.h \
-    libnetmd_extended.h
-SOURCES += common.c error.c libnetmd.c log.c netmd_dev.c playercontrol.c secure.c trackinformation.c utils.c
+    libnetmd_extended.h kataconv.h
+SOURCES += common.c error.c libnetmd.c log.c netmd_dev.c playercontrol.c secure.c trackinformation.c utils.c kataconv.c
 
 include(../build/libgcrypt.pri)
 include(../build/libusb.pri)

--- a/libnetmd/trackinformation.c
+++ b/libnetmd/trackinformation.c
@@ -23,6 +23,7 @@
 
 #include <string.h>
 #include <stdio.h>
+#include <glib.h>
 
 #include "trackinformation.h"
 #include "utils.h"
@@ -91,13 +92,14 @@ int netmd_request_track_flags(netmd_dev_handle*dev, const uint16_t track, unsign
 int netmd_request_title(netmd_dev_handle* dev, const uint16_t track, char* buffer, const size_t size)
 {
     int ret = -1;
-    size_t title_size = 0;
+    size_t title_response_size = 0;
     unsigned char title_request[] = {0x00, 0x18, 0x06, 0x02, 0x20, 0x18,
                                      0x02, 0x00, 0x00, 0x30, 0x00, 0xa,
                                      0x00, 0xff, 0x00, 0x00, 0x00, 0x00,
                                      0x00};
     unsigned char title[255];
     unsigned char *buf;
+    GError * err = NULL;
 
     buf = title_request + 7;
     netmd_copy_word_to_buffer(&buf, track, 0);
@@ -108,23 +110,34 @@ int netmd_request_title(netmd_dev_handle* dev, const uint16_t track, char* buffe
         return -1;
     }
 
-    title_size = (size_t)ret;
+    title_response_size = (size_t)ret;
 
-    if(title_size == 0 || title_size == 0x13)
+    if(title_response_size == 0 || title_response_size == 0x13)
         return -1; /* bail early somethings wrong or no track */
 
     int title_response_header_size = 25;
     const char *title_text = title + title_response_header_size;
-    size_t required_size = title_size - title_response_header_size;
+    size_t encoded_title_size = title_response_size - title_response_header_size;
 
-    if (required_size > size - 1)
+    char * decoded_title_text;
+    decoded_title_text = g_convert(title_text, encoded_title_size, "UTF-8", "SHIFT_JIS", NULL, NULL, &err);
+
+    if(err)
+    {
+        printf("netmd_request_title: title couldn't be converted from SHIFT_JIS to UTF-8: %s", err->message);
+        return -1;
+    }
+
+    size_t decoded_title_size = strlen(decoded_title_text);
+
+    if (decoded_title_size > size - 1)
     {
         printf("netmd_request_title: title too large for buffer\n");
         return -1;
     }
 
     memset(buffer, 0, size);
-    memcpy(buffer, title_text, required_size);
+    memcpy(buffer, decoded_title_text, decoded_title_size);
 
-    return required_size;
+    return decoded_title_size;
 }

--- a/libnetmd/trackinformation.c
+++ b/libnetmd/trackinformation.c
@@ -28,6 +28,7 @@
 
 #include "kataconv.h"
 #include "trackinformation.h"
+#include "const.h"
 #include "utils.h"
 #include "log.h"
 
@@ -122,9 +123,8 @@ int netmd_request_title_raw(netmd_dev_handle* dev, const uint16_t track, char* b
     if(title_response_size == 0 || title_response_size == 0x13)
         return -1; /* bail early somethings wrong or no track */
 
-    int title_response_header_size = 25;
-    const char *title_text = title + title_response_header_size;
-    size_t title_size = title_response_size - title_response_header_size;
+    const char *title_text = title + NETMD_TITLE_RESPONSE_HEADER_SIZE;
+    size_t title_size = title_response_size - NETMD_TITLE_RESPONSE_HEADER_SIZE;
 
     if (title_size > size - 1)
     {

--- a/libnetmd/trackinformation.c
+++ b/libnetmd/trackinformation.c
@@ -120,11 +120,11 @@ int netmd_request_title(netmd_dev_handle* dev, const uint16_t track, char* buffe
     size_t encoded_title_size = title_response_size - title_response_header_size;
 
     char * decoded_title_text;
-    decoded_title_text = g_convert(title_text, encoded_title_size, "UTF-8", "SHIFT_JIS", NULL, NULL, &err);
+    decoded_title_text = g_convert(title_text, encoded_title_size, "UTF-8", "JIS_X0201", NULL, NULL, &err);
 
     if(err)
     {
-        printf("netmd_request_title: title couldn't be converted from SHIFT_JIS to UTF-8: %s", err->message);
+        printf("netmd_request_title: title couldn't be converted from JIS_X0201 to UTF-8: %s", err->message);
         return -1;
     }
 

--- a/libnetmd/trackinformation.c
+++ b/libnetmd/trackinformation.c
@@ -119,12 +119,11 @@ int netmd_request_title(netmd_dev_handle* dev, const uint16_t track, char* buffe
     const char *title_text = title + title_response_header_size;
     size_t encoded_title_size = title_response_size - title_response_header_size;
 
-    char * decoded_title_text;
-    decoded_title_text = g_convert(title_text, encoded_title_size, "UTF-8", "JIS_X0201", NULL, NULL, &err);
+    char * decoded_title_text = g_convert(title_text, encoded_title_size, "UTF-8", "JIS_X0201", NULL, NULL, &err);
 
     if(err)
     {
-        printf("netmd_request_title: title couldn't be converted from JIS_X0201 to UTF-8: %s", err->message);
+        printf("netmd_request_title: title couldn't be converted from JIS_X0201 to UTF-8: %s\n", err->message);
         return -1;
     }
 
@@ -138,6 +137,7 @@ int netmd_request_title(netmd_dev_handle* dev, const uint16_t track, char* buffe
 
     memset(buffer, 0, size);
     memcpy(buffer, decoded_title_text, decoded_title_size);
+    g_free(decoded_title_text);
 
     return decoded_title_size;
 }

--- a/libnetmd/trackinformation.c
+++ b/libnetmd/trackinformation.c
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <glib.h>
 
+#include "kataconv.h"
 #include "trackinformation.h"
 #include "utils.h"
 #include "log.h"
@@ -126,6 +127,8 @@ int netmd_request_title(netmd_dev_handle* dev, const uint16_t track, char* buffe
         printf("netmd_request_title: title couldn't be converted from JIS_X0201 to UTF-8: %s\n", err->message);
         return -1;
     }
+
+    kata_half_to_full((uint8_t*)decoded_title_text);
 
     size_t decoded_title_size = strlen(decoded_title_text);
 

--- a/libnetmd/trackinformation.h
+++ b/libnetmd/trackinformation.h
@@ -29,7 +29,7 @@ int netmd_request_track_flags(netmd_dev_handle* dev, const uint16_t track, unsig
    Get the title for a specific track.
 
    Titles retrieved using this function are converted to
-   UTF-8 or your convenience.
+   UTF-8 for your convenience.
 
    @param dev pointer to device returned by netmd_open
    @param track Zero based index of track your requesting.

--- a/libnetmd/trackinformation.h
+++ b/libnetmd/trackinformation.h
@@ -2,6 +2,7 @@
 #define LIBNETMD_TRACKINFORMATION_H
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "common.h"
 
@@ -27,6 +28,9 @@ int netmd_request_track_flags(netmd_dev_handle* dev, const uint16_t track, unsig
 /**
    Get the title for a specific track.
 
+   Titles retrieved using this function are converted to
+   UTF-8 or your convenience.
+
    @param dev pointer to device returned by netmd_open
    @param track Zero based index of track your requesting.
    @param buffer buffer to hold the name.
@@ -35,5 +39,25 @@ int netmd_request_track_flags(netmd_dev_handle* dev, const uint16_t track, unsig
            recall function.
 */
 int netmd_request_title(netmd_dev_handle* dev, const uint16_t track, char* buffer, const size_t size);
+
+/**
+   Get the raw title for a specific track.
+
+   Narrow titles will be returned as raw JIS X0201 text,
+   wide titles will be returned as raw Shift JIS text.
+   A given MiniDisc track may only have one set.
+
+   For automatic detection, and UTF-8 conversion,
+   please use netmd_request_title instead.
+
+   @param dev pointer to device returned by netmd_open
+   @param track Zero based index of track your requesting.
+   @param buffer buffer to hold the name.
+   @param size of buf.
+   @param whether to request the narrow or wide title.
+   @return Actual size of buffer, if your buffer is too small resize buffer and
+           recall function.
+*/
+int netmd_request_title_raw(netmd_dev_handle* dev, const uint16_t track, char* buffer, const size_t size, bool wide_chars);
 
 #endif


### PR DESCRIPTION
Wow! We’ve come a long, long way from when I first wrote this! I’ve converted this to a draft PR so it’s clear there’s ongoing work and discussion here.

Ongoing discussion relates to implementing handling for group titles, which are [tricky due to how they’re stored on the MiniDisc](https://github.com/linux-minidisc/linux-minidisc/pull/56#issuecomment-609107256). My [current proposal is that the routines for parsing disc information be updated to handle both title fields at once](https://github.com/linux-minidisc/linux-minidisc/pull/56#issuecomment-629058430), so that there’s no possibility of losing data on any given group edit action.

---

Similarly to #55 (and tested on the same discs!), this updates `libnetmd` to handle conversion of track and disc titles from UTF-8 to their target encodings in a similar way to `libhimd`.

From extensive research over the course of several weeks, I have determined* that narrow MiniDisc titles are JIS X0201 encoded. JIS X0201 is an older Japanese text encoding which includes all of the basic ASCII set for latin text, as well as a set of Japanese Katakana characters.

MiniDiscs also feature a “wide” title field, which is encoded as Shift JIS for greater character support (including Hiragana and many Kanji) supported primarily by high-end LCD remote controls (RM-MC35ELK and the like, the “K” in the model number seems to be the important bit!).

Previously, `libnetmd` has only handled narrow titles, and has put whatever bytes you give it into the player’s narrow title field unadulterated. This means that, if you have a modern system configured for UTF-8, you can set titles which the player has no means of displaying!

This pull request updates `libnetmd` behind the scenes such that the `netmd_set_title` and `netmd_set_disc_title` will encode your UTF-8 inputs as either JIS X0201, or Shift JIS, depending on their contents, and then write the result to the field they fit in. It additionally updates the `netmd_request_title` and `request_disc_title` functions to decode the JIS encoded text into UTF-8, and automatically select the correct field to draw on.

For the character set conversion, this adds a dependency on `glib` to `libnetmd`, but given `libhimd`’s reliance this doesn’t seem like a big deal.

Finally, to improve the ergonomics of handling Japanese text on a modern computer, these functions will also convert the half-width Katakana characters into full-width Unicode Katakana for display, and full-width Unicode Katakana into half-width Katakana when writing half-width titles.

Prior to this pull request, `netmdcli` has this to show for a Japanese-titled disc on a modern UTF-8 system:
<img width="418" alt="image" src="https://user-images.githubusercontent.com/282113/77134504-93d81400-6a24-11ea-8c3b-8bd106c98833.png">

With this pull request applied, `netmdcli` now shows this for the same disc:
<img width="499" alt="image" src="https://user-images.githubusercontent.com/282113/78091895-0cbf6000-7383-11ea-8e28-409dc1bdd43e.png">

---

*I am certainly not the first to discover this fact - [Wikipedia](https://en.wikipedia.org/w/index.php?title=Katakana&oldid=948283472#Half-width_kana) notes the encoding of half-width Katakana, and [win nmd, for instance](http://winnmd.net/winnmd.htm) makes reference to the Shift JIS field’s existence. I have verified this by testing many strings against my Shift JIS incapable MZ-M10 player, and with my Shift JIS capable RM-MC35ELK LCD remote, as well as by observing and testing the behaviour of both English and Japanese versions of SonicStage with Japanese text. Nobody on the internet seemingly outright states that the encodings are these two encodings, but the character set support and behaviour of both players, and SonicStage, make me certain.