### PR TITLE
QNetMDTracksModel: Avoid crash due to permission error

### DIFF
--- a/qhimdtransfer/qmdmodel.cpp
+++ b/qhimdtransfer/qmdmodel.cpp
@@ -129,8 +129,10 @@ QString QNetMDTracksModel::open(QMDDevice * device)
         ret = ndev->open();
     }
 
-    if(!ret.isEmpty())
+    if(!ret.isEmpty()) {
         close();
+        return ret;
+    }
 
     /* fetch track info for all tracks first, getting track info inside data() function is very slow */
     for(; i < ndev->trackCount(); i++)


### PR DESCRIPTION
This fixes a crash when the current user doesn't have permission to open the NetMD device.

Steps to reproduce:

1. Remove the `/etc/udev/rules.d/netmd.rules` file or remove the user from the `plugdev` group.
2. Run QHiMDTransfer