### PR TITLE
Added support for Sony MZ-RH1 with alternate USB ID (054c:0287) to netmd

### DIFF
--- a/netmd/etc/netmd.rules
+++ b/netmd/etc/netmd.rules
@@ -36,6 +36,7 @@ ATTRS{idVendor}=="054c", ATTRS{idProduct}=="023c", MODE="0664", GROUP="plugdev"
 
 # Sony MZ-RH1
 ATTRS{idVendor}=="054c", ATTRS{idProduct}=="0286", MODE="0664", GROUP="plugdev"
+ATTRS{idVendor}=="054c", ATTRS{idProduct}=="0287", MODE="0664", GROUP="plugdev"
 
 
 ## NetMD

--- a/netmd/libnetmd.py
+++ b/netmd/libnetmd.py
@@ -56,6 +56,7 @@ KNOWN_USB_ID_SET = frozenset([
     (0x054c, 0x022c), # Sony CMT-AH10 (stereo set with integrated MD)
     (0x054c, 0x023c), # Sony DS-HMD1 (device without analog music rec/playback)
     (0x054c, 0x0286), # Sony MZ-RH1
+    (0x054c, 0x0287), # Sony MZ-RH1
 ])
 
 def iterdevices(usb_context, bus=None, device_address=None):


### PR DESCRIPTION
This is necessary to support a black "Hi-MD WALKMAN MZ-RH1" sold in France.

Hi-MD:

  Product ID:	0x0287
  Vendor ID:	0x054c  (Sony Corporation)
  Version:	1.00
  Serial Number:	02000122F22C
  Speed:	Up to 480 Mb/s
  Manufacturer:	Sony
  Location ID:	0x14100000 / 12
  Current Available (mA):	500
  Current Required (mA):	500
  Extra Operating Current (mA):	0