### PR TITLE
Ensure pkg-config is correctly queried

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
       compiler: gcc
       env: BUILD_TYPE=linux-cross-mingw32 CONFIGURE_COMMAND="sh build/cross_wrapper_mingw.sh qmake" COMPILE_COMMAND="sh build/cross_wrapper_mingw.sh make"
     - os: osx
-      osx_image: xcode7.2
+      osx_image: xcode10.2
       language: cpp
       compiler: clang
       env: BUILD_TYPE=osx-native-clang

--- a/build/libgcrypt.pri
+++ b/build/libgcrypt.pri
@@ -1,5 +1,28 @@
 !without_gcrypt {
-  LIBS += -lgcrypt
+  # We use qt's own check to see if pkg-config can find libgcrypt, and if it can't, fall back to libgcrypt-config
+  # https://github.com/qt/qtbase/blob/5.3/mkspecs/features/qt_functions.prf#L323-L336
+  packagesExist(libgcrypt) {
+    PKGCONFIG += libgcrypt
+  } else {
+    # The following is based upon the qt5 link_pkgconfig mkspec logic:
+    # https://github.com/qt/qtbase/blob/5.3/mkspecs/features/link_pkgconfig.prf#L12-L27
+    GCRYPT_CONFIG_CFLAGS = $$system(libgcrypt-config --cflags)
+
+    GCRYPT_CONFIG_INCLUDEPATH = $$find(GCRYPT_CONFIG_CFLAGS, ^-I.*)
+    GCRYPT_CONFIG_INCLUDEPATH ~= s/^-I(.*)/\\1/g
+
+    GCRYPT_CONFIG_DEFINES = $$find(GCRYPT_CONFIG_CFLAGS, ^-D.*)
+    GCRYPT_CONFIG_DEFINES ~= s/^-D(.*)/\\1/g
+
+    GCRYPT_CONFIG_CFLAGS ~= s/^-[ID].*//g
+
+    INCLUDEPATH *= $$GCRYPT_CONFIG_INCLUDEPATH
+    DEFINES *= $$GCRYPT_CONFIG_DEFINES
+
+    QMAKE_CXXFLAGS += $$GCRYPT_CONFIG_CFLAGS
+    QMAKE_CFLAGS += $$GCRYPT_CONFIG_CFLAGS
+    LIBS += $$system(libgcrypt-config --libs)
+  }
   DEFINES += CONFIG_WITH_GCRYPT
 }
 else: !build_pass: message(You disabled gcrypt: No PCM and ATRAC transfer will be supported)

--- a/himdcli/himdcli.pro
+++ b/himdcli/himdcli.pro
@@ -6,9 +6,7 @@ CONFIG += console link_pkgconfig link_prl
 SOURCES += himdcli.c
 
 include(../libhimd/use_libhimd.pri)
-include(../build/libid3tag.pri)
 include(../build/libmad.pri)
-include(../build/libz.pri)
 include(../build/libglib.pri)
 include(../build/installunix.pri)
 include(../build/common.pri)

--- a/libhimd/libhimd.pro
+++ b/libhimd/libhimd.pro
@@ -6,6 +6,8 @@ CONFIG += staticlib link_pkgconfig create_prl console debug_and_release_target
 HEADERS += codecinfo.h himd.h himd_private.h sony_oma.h
 SOURCES += codecinfo.c encryption.c himd.c mdstream.c trackindex.c sony_oma.c frag.c mp3tools.c mp3download.c
 
+include(../build/libid3tag.pri)
+include(../build/libz.pri)
 include(../build/libmad.pri)
 include(../build/libgcrypt.pri)
 include(../build/libglib.pri)

--- a/netmdcli/netmdcli.pro
+++ b/netmdcli/netmdcli.pro
@@ -4,6 +4,7 @@ CONFIG += console link_pkgconfig link_prl
 SOURCES += netmdcli.c
 
 include(../libnetmd/use_libnetmd.prl)
+include(../build/libgcrypt.pri)
 include(../build/libusb.pri)
 include(../build/installunix.pri)
 include(../build/common.pri)


### PR DESCRIPTION
Previously, pkg-config was not invoked for `libgcrypt`, and both it and `libid3tag` was not required by all its dependent modules, and therefore non-standard installation locations for these dependencies would fail to be found. This updates the project files to correctly wire through the dependencies.

This patch does the following:

- `build/libgcrypt.pri`: Use qmake's `PKGCONFIG` variable rather than `LIBS`
- `libhimd/libhimd.pro`: Add `libid3tag.pri` and `libz.pri` as they [are used by libhimd](https://github.com/linux-minidisc/linux-minidisc/blob/43a01190f819e44c5709017b889be9bf8766b989/libhimd/mp3tools.c#L26)
- `himdcli/himdcli.pro`: Remove `libid3tag.pri` and `libz.pri` as they are moved to `libhimd/libhimd.pro`
- `netmdcli/netmdcli.pro`: Add `libgcrypt.pri` as it [is used by netmdcli](https://github.com/linux-minidisc/linux-minidisc/blob/43a01190f819e44c5709017b889be9bf8766b989/netmdcli/netmdcli.c#L22)

This also uses libgcrypt-config utility if pkg-config metadata is missing for it

This should allow us to use the more-correct pkg-config metadata where available, while maintaining backwards compatibility with earlier versions of libgcrypt which don't provide pkg-config metadata.

Finally, this bumps the Travis configuration to to macOS 10.14 (Using the "xcode10.2" Travis image) as the currently specified image has been retired by Travis, causing all Mac CI builds to break.

This was the result of much experimentation in #70, and has now been rebased for final merging. Fixes #69.

I appear to not be allowed to assign reviewers, so, cc: @glaubitz, @karcherm