### PR TITLE
Fix build with Qt 5.11 (Fixes #73)

### DIFF
--- a/qhimdtransfer/qhimdmainwindow.cpp
+++ b/qhimdtransfer/qhimdmainwindow.cpp
@@ -289,7 +289,7 @@ void QHiMDMainWindow::device_list_changed(QMDDevicePtrList dplist)
     foreach(dev, dplist)
     {
         device = QString(dev->deviceType() == NETMD_DEVICE ? dev->name() : dev->name() + " at " + dev->path() );
-        ui->himd_devices->addItem(device, qVariantFromValue((void *)dev));
+        ui->himd_devices->addItem(device, QVariant::fromValue((void *)dev));
     }
 
     if(current_device)

--- a/qhimdtransfer/qmdmodel.cpp
+++ b/qhimdtransfer/qmdmodel.cpp
@@ -26,11 +26,11 @@ QVariant QNetMDTracksModel::headerData(int section, Qt::Orientation orientation,
         switch((ncolumnum)section)
         {
             case CoId:
-                return QSize(met.width("9999")+5, 0);
+                return QSize(met.horizontalAdvance("9999")+5, 0);
             case CoGroup:
             case CoTitle:
             case CoLength:
-                return QSize(met.width("9:99:99"), 0);
+                return QSize(met.horizontalAdvance("9:99:99"), 0);
             case CoCodec:
             case CoUploadable:
                 /* Really use the header for the metric in these columns,
@@ -175,20 +175,20 @@ QVariant QHiMDTracksModel::headerData(int section, Qt::Orientation orientation, 
         switch((hcolumnum)section)
         {
             case ColId:
-                return QSize(met.width("9999")+5, 0);
+                return QSize(met.horizontalAdvance("9999")+5, 0);
             case ColTitle:
             case ColArtist:
             case ColAlbum:
                 return QSize(25*met.averageCharWidth(), 0);
             case ColLength:
-                return QSize(met.width("9:99:99"), 0);
+                return QSize(met.horizontalAdvance("9:99:99"), 0);
             case ColCodec:
             case ColUploadable:
                 /* Really use the header for the metric in these columns,
                    contents will be shorter */
                 return QAbstractListModel::headerData(section,orientation,role);
             case ColRecDate:
-                return QSize(met.width("yyyy.MM.dd hh:mm:ss"), 0);
+                return QSize(met.horizontalAdvance("yyyy.MM.dd hh:mm:ss"), 0);
         }
     }
 


### PR DESCRIPTION
Replace usage of obsolete functionality (since Qt 5.11):

https://doc.qt.io/qt-5/qvariant-obsolete.html#qVariantFromValue
https://doc.qt.io/qt-5/qfontmetrics-obsolete.html#width

I haven't checked what Qt version distros provide, depending on the need for backwards compatibility with older Qt versions, this might need to be ifdeffed or macros/templates used to support both old and new Qt versions.