### PR TITLE
Fix writing disc header

### DIFF
--- a/libnetmd/libnetmd.c
+++ b/libnetmd/libnetmd.c
@@ -812,7 +812,7 @@ char* netmd_generate_disc_header(minidisc* md, char* header, size_t header_lengt
     int result;
 
     position = header;
-    remaining = header_length - 1;
+    remaining = header_length;
 
     if (md->groups[0].start == 0)
     {
@@ -884,6 +884,7 @@ int netmd_write_disc_header(netmd_dev_handle* devh, minidisc* md)
 
     ret = netmd_exch_message(devh, request, request_size, reply);
     free(request);
+    free(header);
 
     return ret;
 }


### PR DESCRIPTION
This is a minor fix, in fact it makes me wonder if it is just me as it has been in there since c8906140c2fd5e3289fd99e194069627028008a3 so my apologies if this isn't an issue and it is just my system being weird.

Creating a group breaks the disc header because the remaining variable accounts for the null character (I assume), but everywhere I looked states that `snprintf` does as well. Since room for the the null character is being made twice this causes the last '/' to be chopped off. While in there I saw that header was never freed as well.