### PR TITLE
Fix generation of MP3 codec flags

### DIFF
--- a/libhimd/mp3download.c
+++ b/libhimd/mp3download.c
@@ -150,12 +150,12 @@ gint write_blocks(struct mad_stream *stream, struct himd_writestream *write_stre
 	mad_timer_add(&mad_timer, header.duration);
 
 	if(firsttime) {
-            bmpegvers =     mpegvers;
-            bmpeglayer =    mpeglayer;
-            bmpegbitrate =  mpegbitrate;
-            bmpegsamprate = mpegsamprate;
-            bmpegchmode =   mpegchmode;
-            bmpegpreemph =  mpegpreemph;
+            mpegvers =     bmpegvers;
+            mpeglayer =    bmpeglayer;
+            mpegbitrate =  bmpegbitrate;
+            mpegsamprate = bmpegsamprate;
+            mpegchmode =   bmpegchmode;
+            mpegpreemph =  bmpegpreemph;
 	    firsttime = FALSE;
 	} else {
 	    if(bmpegvers != mpegvers) {


### PR DESCRIPTION
The configuration of the first frame is supposed to be stored as "reference configuration", not to be overwritten by some default parameters.