### PR TITLE
Cleanup fragment type handling

### DIFF
--- a/libhimd/mp3download.c
+++ b/libhimd/mp3download.c
@@ -319,7 +319,7 @@ int himd_writemp3(struct himd * h, const char *filepath)
     memset(&fragment.key[0], 0, 8); /* use zero key on mp3 files */
     fragment.firstframe = 0;
     fragment.lastframe  = nframes;
-    fragment.fragtype   = 1;
+    fragment.fragtype   = 0;
     fragment.nextfrag   = 0;
 
     idx_frag  = himd_add_fragment_info(h, &fragment, &status);

--- a/libhimd/trackindex.c
+++ b/libhimd/trackindex.c
@@ -171,7 +171,7 @@ static void setfrag(struct fraginfo *f, unsigned char * fragbuffer)
   setbeword16(fragbuffer+10, f->lastblock);
   fragbuffer[12] = f->firstframe;
   fragbuffer[13] = f->lastframe;
-  setbeword16(fragbuffer+14,f->nextfrag);
+  setbeword16(fragbuffer+14, (f->nextfrag) | (f->fragtype << 12));
 }
 
 int himd_get_free_trackindex(struct himd * himd)


### PR DESCRIPTION
Currently, the value assigned to fragtype field of fragments created by the MP3 download code is set to a bad value, that never gets serialized into the TRKIDX0x file. This pull request fixes the bad type, and adds the feature to create fragments with non-zero type.